### PR TITLE
download_pypi_top.py: Start counting at 1

### DIFF
--- a/cpython/download_pypi_top.py
+++ b/cpython/download_pypi_top.py
@@ -92,7 +92,7 @@ def main():
     nproject = len(projs)
     print(f"Project#: {nproject}")
 
-    for index, proj in enumerate(projs):
+    for index, proj in enumerate(projs, start=1):
         try:
             download_sdist(dst_dir, index, proj, nproject)
         except Exception:


### PR DESCRIPTION
# Before

The `[0/5]` -> `[4/5]` looks a little odd:

```console
$ python cpython/download_pypi_top.py out 5
Download JSON from: https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json
Project#: 5
[0/5] Saving to out/boto3-1.21.22.tar.gz (101.5 kB)
[1/5] Saving to out/botocore-1.24.22.tar.gz (8632.5 kB)
[2/5] Saving to out/setuptools-60.10.0.tar.gz (2364.0 kB)
[3/5] Saving to out/urllib3-1.26.9.tar.gz (288.3 kB)
[4/5] Saving to out/s3transfer-0.5.2.tar.gz (131.7 kB)
Downloaded 5 projects in 2.5 seconds
```

# After

Count from `[1/5]` to `[5/5]`:

```console
$ python cpython/download_pypi_top.py out 5
Download JSON from: https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json
Project#: 5
[1/5] Saving to out/boto3-1.21.22.tar.gz (101.5 kB)
[2/5] Saving to out/botocore-1.24.22.tar.gz (8632.5 kB)
[3/5] Saving to out/setuptools-60.10.0.tar.gz (2364.0 kB)
[4/5] Saving to out/urllib3-1.26.9.tar.gz (288.3 kB)
[5/5] Saving to out/s3transfer-0.5.2.tar.gz (131.7 kB)
Downloaded 5 projects in 1.8 seconds
```