### PR TITLE
download_pypi_top.py: add some colour

### DIFF
--- a/cpython/download_pypi_top.py
+++ b/cpython/download_pypi_top.py
@@ -22,9 +22,17 @@ import requests
 import traceback
 import json
 import os
+import sys
 import time
 
-from termcolor import cprint
+
+try:
+    from termcolor import cprint
+except ImportError:
+    print("termcolor is missing, install it with: python -m pip install --user termcolor", file=sys.stderr)
+
+    def cprint(msg, *ignored):
+        print(msg)
 
 
 session = requests.Session()

--- a/cpython/download_pypi_top.py
+++ b/cpython/download_pypi_top.py
@@ -22,8 +22,10 @@ import requests
 import traceback
 import json
 import os
-import sys
 import time
+
+from termcolor import cprint
+
 
 session = requests.Session()
 
@@ -31,11 +33,12 @@ JSON_URL = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days
 
 
 def projects():
-    print("Download JSON from: %s" % JSON_URL)
+    cprint(f"Download JSON from: {JSON_URL}", "green")
     resp = session.get(JSON_URL)
     resp.raise_for_status()
     top = json.loads(resp.content)
     return [p["project"] for p in top["rows"]]
+
 
 def find_url(proj):
     resp = session.get(f"https://pypi.org/pypi/{proj}/json")
@@ -46,24 +49,26 @@ def find_url(proj):
             return entry["url"]
     return None
 
+
 def download_sdist(dst_dir, index, proj, nproject):
     url = find_url(proj)
     if not url:
         # Universal wheel only, maybe.
-        print(f"Cannot find URL for project: {proj}")
+        cprint(f"Cannot find URL for project: {proj}", "red")
         return
     filename = url[url.rfind('/')+1:]
     filename = os.path.join(dst_dir, filename)
     if os.path.exists(filename):
-        print(f"Exists: {filename}")
+        cprint(f"Exists: {filename}", "yellow")
         return
     resp = session.get(url)
     resp.raise_for_status()
     content = resp.content
-    print(f"[{index}/{nproject}] "
-          f"Saving to {filename} ({len(content) / 1024.:.1f} kB)")
+    cprint(f"[{index}/{nproject}] "
+           f"Saving to {filename} ({len(content) / 1024.:.1f} kB)", "green")
     with open(filename, "wb") as f:
         f.write(content)
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Download the source code of PyPI top projects.')
@@ -97,10 +102,11 @@ def main():
             download_sdist(dst_dir, index, proj, nproject)
         except Exception:
             traceback.print_exc()
-            print(f"Failed to download {proj}")
+            cprint(f"Failed to download {proj}", "red")
 
     dt = time.monotonic() - start_time
-    print(f"Downloaded {nproject} projects in {dt:.1f} seconds")
+    cprint(f"Downloaded {nproject} projects in {dt:.1f} seconds", "green")
+
 
 if __name__ == "__main__":
     main()

--- a/cpython/download_pypi_top.py
+++ b/cpython/download_pypi_top.py
@@ -29,7 +29,8 @@ import time
 try:
     from termcolor import cprint
 except ImportError:
-    print("termcolor is missing, install it with: python -m pip install --user termcolor", file=sys.stderr)
+    print("Warning: termcolor is missing, install it with: python -m pip install --user termcolor", file=sys.stderr)
+    print(file=sys.stderr)
 
     def cprint(msg, *ignored):
         print(msg)


### PR DESCRIPTION
Add some green, yellow and red colour for feedback, using [termcolor](https://pypi.org/project/termcolor/):

<img width="704" alt="image" src="https://user-images.githubusercontent.com/1324225/159174533-08cdf78d-0a0a-414e-bb19-176a14fd910f.png">

Normally colours should be disabled when not in a tty, so that the colour codes aren't included when piping to another command or redirecting to file.

But I don't think we need to worry about the output of `download_pypi_top.py` will be piped to a file? It would be straightforward to add tty handling too, let me know if needed!

(~`search_pypi_top.py` is different and I sometimes log to a file, so that would need tty handling.~ Actually probably not needed because it has `--output` built in :)
