### PR TITLE
search_pypi_top.py: add some colour

### DIFF
--- a/cpython/search_pypi_top.py
+++ b/cpython/search_pypi_top.py
@@ -117,7 +117,7 @@ def decompress_tar(args, archive_filename, mode):
             if fp is None:
                 continue
             with fp:
-                yield (filename, fp)
+                yield filename, fp
 
 
 def decompress_zip(args, archive_filename):
@@ -128,7 +128,7 @@ def decompress_zip(args, archive_filename):
                 log_ignored_file(archive_filename, filename)
                 continue
             with zf.open(member) as fp:
-                yield (filename, fp)
+                yield filename, fp
 
 
 def decompress(args, filename):

--- a/cpython/search_pypi_top.py
+++ b/cpython/search_pypi_top.py
@@ -186,14 +186,17 @@ def search_file(filename, index, len_filenames, args, pypi_dir, regex):
     for name, line, span in grep(args, filename, regex):
         line = line.decode('utf8', 'replace')
 
+        # print to terminal with color
         start, end = span
-        line = (
+        line_color = (
             line[:start] + colored(line[start:end], "red", attrs=["bold"]) + line[end:]
-        ).strip()
-
-        name = colored(name, "magenta")
-        result = f"{filename}: {name}: {line}\n"
+        )
+        name_color = colored(name, "magenta")
+        result = f"{filename}: {name_color}: {line_color.strip()}\n"
         print(result, flush=True, end="")
+
+        # print to file without color
+        result = f"{filename}: {name}: {line.strip()}\n"
         results.append(result)
         lines += 1
 


### PR DESCRIPTION
Similar to https://github.com/vstinner/misc/pull/15.

Add some colour to `search_pypi_top.py` to improve readability. Use same colours as grep, magenta and bold red.

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/1324225/174493766-7db2ffca-3827-4990-acc7-3e41dbaa01f7.png">

Doesn't cause any noticeable delay, here's the same search with `main`:

```console
$ python search_pypi_top.py out-2022-06-12 "\b(currentThread|activeCount|notifyAll|isSet|isDaemon|setDaemon)\b" -q
```

<img width="1500" alt="image" src="https://user-images.githubusercontent.com/1324225/174493781-5de64472-a1e2-4a7b-803e-c4f8b5452b56.png">
