### PR TITLE
Ignore some files from the initial directory listing

### DIFF
--- a/cpython/search_pypi_top.py
+++ b/cpython/search_pypi_top.py
@@ -38,6 +38,8 @@ except ImportError:
 
 
 IGNORE_CYTHON = True
+# Ignore these files from the initial directory listing
+IGNORED_FILENAMES = (".DS_Store",)
 # Ignore file extensions known to be binary files to avoid the slow
 # is_binary_string() check
 IGNORED_FILE_EXTENSIONS = (
@@ -213,7 +215,9 @@ def search_dir(args, pypi_dir, pattern):
     projects = set()
     all_results = []
     regex = re.compile(pattern)
-    filenames = os.listdir(pypi_dir)
+    filenames = sorted(
+        (f for f in os.listdir(pypi_dir) if f not in IGNORED_FILENAMES), key=str.lower
+    )
 
     with multiprocessing.Pool() as pool:
         ret = pool.starmap(

--- a/cpython/search_pypi_top.py
+++ b/cpython/search_pypi_top.py
@@ -38,8 +38,8 @@ except ImportError:
 
 
 IGNORE_CYTHON = True
-# Ignore these files from the initial directory listing
-IGNORED_FILENAMES = (".DS_Store",)
+# Ignore macOS directory metadata files from the initial directory listing
+DS_STORE = ".DS_Store"
 # Ignore file extensions known to be binary files to avoid the slow
 # is_binary_string() check
 IGNORED_FILE_EXTENSIONS = (
@@ -215,9 +215,8 @@ def search_dir(args, pypi_dir, pattern):
     projects = set()
     all_results = []
     regex = re.compile(pattern)
-    filenames = sorted(
-        (f for f in os.listdir(pypi_dir) if f not in IGNORED_FILENAMES), key=str.lower
-    )
+    filenames = (filename for filename in os.listdir(pypi_dir) if filename != DS_STORE)
+    filenames = sorted(filenames, key=str.lower)
 
     with multiprocessing.Pool() as pool:
         ret = pool.starmap(


### PR DESCRIPTION
`.DS_Store` is a file that macOS annoyingly peppers in directories when you view them in the Finder file browser app (https://en.wikipedia.org/wiki/.DS_Store).

And causes problems when running `search_pypi_top.py`:

```pytb
$ python3 ~/github/misc/cpython/search_pypi_top.py -q . "ob_digit"
./numba-0.57.1.tar.gz: numba-0.57.1/numba/cpython/hashing.py: # the shift and mask splits out the `ob_digit` parts of a Long repr
./gevent-22.10.2.tar.gz: gevent-22.10.2/src/gevent/_generated_include/CIntFromPy_impl_1acd853eb242f2a14b63ea0b7665ba0aef1c09de.h: const digit* digits = ((PyLongObject*)x)->ob_digit;
<snip>
./catboost-1.2.tar.gz: catboost-1.2/catboost_all_src/contrib/tools/cython/Cython/Utility/TypeConversion.c: const digit* digits = ((PyLongObject*)x)->ob_digit;
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/misc/cpython/search_pypi_top.py", line 191, in search_file
    for name, line, span in grep(args, filename, regex):
  File "/Users/hugo/github/misc/cpython/search_pypi_top.py", line 161, in grep
    for filename, fp in decompress(args, archive_filename):
  File "/Users/hugo/github/misc/cpython/search_pypi_top.py", line 147, in decompress
    raise Exception(f"unsupported filename: {filename!r}")
Exception: unsupported filename: './.DS_Store'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/hugo/github/misc/cpython/search_pypi_top.py", line 303, in <module>
    main()
  File "/Users/hugo/github/misc/cpython/search_pypi_top.py", line 295, in main
    _main()
  File "/Users/hugo/github/misc/cpython/search_pypi_top.py", line 279, in _main
    lines, projects, results = search_dir(args, pypi_dir, pattern)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/misc/cpython/search_pypi_top.py", line 219, in search_dir
    ret = pool.starmap(
          ^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/pool.py", line 375, in starmap
    return self._map_async(func, iterable, starmapstar, chunksize).get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/pool.py", line 774, in get
    raise self._value
Exception: unsupported filename: './.DS_Store'
```

Let's skip it from the initial directory listing, because we only want compressed files like zips and tarfiles so on.

---

I also sorted the list of files returned from `os.listdir`, because it returns them in an arbitrary order. However, we're then batching the files into multiprocessing, so the output is still shuffled a bit, but at least now they're in slightly less random order.
