### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/cpython/download_pypi_top.py
+++ b/cpython/download_pypi_top.py
@@ -15,7 +15,7 @@
 # https://hugovk.github.io/top-pypi-packages/
 #
 # Try:
-# https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json
+# https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json
 
 import argparse
 import requests
@@ -39,7 +39,7 @@ except ImportError:
 
 session = requests.Session()
 
-JSON_URL = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json'
+JSON_URL = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json'
 
 
 def projects():


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.